### PR TITLE
Fix issue #1 by making the LOGIN_URL pattern more specific

### DIFF
--- a/privateviews/middleware.py
+++ b/privateviews/middleware.py
@@ -18,7 +18,7 @@ class LoginRequiredMiddleware(object):
             for public_path in settings.PUBLIC_PATHS:
                 self.public_patterns.append(re.compile(public_path))
         if hasattr(settings, 'LOGIN_URL'):
-            pattern = re.compile(re.escape(settings.LOGIN_URL))
+            pattern = re.compile(r'^%s$' % re.escape(settings.LOGIN_URL))
             self.public_patterns.append(pattern)
 
     def get_view(self, view_path):


### PR DESCRIPTION
Wraps the escaped LOGIN_URL in ^/$ to match only that request path.
